### PR TITLE
chore: Support for Node.js 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@strapi/utils": "^4.1.8",
-    "socket.io": "^4.4.1",
-    "socket.io-client": "^4.4.1"
+    "@strapi/utils": "^4.6.0",
+    "socket.io": "^4.5.4",
+    "socket.io-client": "^4.5.4"
   },
   "peerDependencies": {
     "@strapi/strapi": "^4.1.8"
   },
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=14.19.1 <=18.x.x",
     "npm": ">=6.0.0"
   },
   "main": "strapi-admin.js",


### PR DESCRIPTION
Strapi supports Node version 18 since version [4.3.9](https://github.com/strapi/strapi/releases/tag/v4.3.9), commit https://github.com/strapi/strapi/pull/14350. 

In the project running Node 18 we are unable to install `@notum-cz/strapi-plugin-record-locking`, because in `package.json` is [limited](https://github.com/notum-cz/strapi-plugin-record-locking/blob/main/package.json#L26-L29)  maximum Node version 16
```
  "engines": {
    "node": ">=12.x.x <=16.x.x",
    "npm": ">=6.0.0"
  },
```

To match `Strapi` we should use 
```
  "engines": {
    "node": ">=14.19.1 <=18.x.x",
    "npm": ">=6.0.0"
  },
```

---

⚠️  The project is lacking `package-lock.json`, `yarn.lock` or other `lock` file.