### PR TITLE
Feature/add transport config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ module.exports = ({ env }) => ({
 });
 ```
 
+We use websockets and you can determine the necessary transport yourself:
+```js
+module.exports = ({ env }) => ({
+ "record-locking": {
+     enabled: true,
+     config: {
+         transports: ["websocket"]
+     }
+  },
+});
+```
+
+If you do not specify a transport, the default parameters will be applied:
+```js
+DEFAULT_TRANSPORTS: ["polling", "websocket", "webtransport"]
+```
+
+
 ### 3. Enable websocket support by configuring the Strapi middleware.
 
 In the `config/middlewares.js` file either replace `'strapi::security'` with  a middleware object (see the example below) or update your existing configuration accordingly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notum-cz/strapi-plugin-record-locking",
-  "version": "2.0.0",
+  "version": "1.3.6",
   "description": "Hey I am editing, don't change my content",
   "strapi": {
     "displayName": "Record locking",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notum-cz/strapi-plugin-record-locking",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "description": "Hey I am editing, don't change my content",
   "strapi": {
     "displayName": "Record locking",

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -1,6 +1,14 @@
+const { Server } = require("socket.io")
+const {DEFAULT_TRANSPORTS} = require("./constants/transports");
+
 module.exports = ({ strapi }) => {
   // bootstrap phase
-  const io = require("socket.io")(strapi.server.httpServer);
+
+  const config = strapi.config.get('plugin.record-locking')
+
+  const io = new Server(strapi.server.httpServer, {
+    transports: config?.transports || DEFAULT_TRANSPORTS
+  });
 
   io.on("connection", function (socket) {
     socket.on("openEntity", async ({ entitySlug, entityId }) => {

--- a/server/constants/transports.js
+++ b/server/constants/transports.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  DEFAULT_TRANSPORTS: ["polling", "websocket", "webtransport"]
+}

--- a/server/controllers/entity-lock.js
+++ b/server/controllers/entity-lock.js
@@ -1,6 +1,13 @@
 "use strict";
 
 module.exports = {
+  async getSettings(ctx) {
+    const settings = {
+      transports: strapi.plugin('record-locking').config('transports')
+    }
+
+    ctx.send(settings);
+  },
   async getStatusBySlug(ctx) {
     const { slug } = ctx.request.params;
     const { id: userId } = ctx.state.user;

--- a/server/controllers/entity-lock.js
+++ b/server/controllers/entity-lock.js
@@ -1,9 +1,11 @@
 "use strict";
 
+const {DEFAULT_TRANSPORTS} = require("../constants/transports");
+
 module.exports = {
   async getSettings(ctx) {
     const settings = {
-      transports: strapi.plugin('record-locking').config('transports')
+      transports: strapi.plugin('record-locking').config('transports') || DEFAULT_TRANSPORTS
     }
 
     ctx.send(settings);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,14 @@
 module.exports = [
   {
     method: "GET",
+    path: "/settings",
+    handler: "entityLock.getSettings",
+    config: {
+      policies: [],
+    },
+  },
+  {
+    method: "GET",
     path: "/get-status/:slug",
     handler: "entityLock.getStatusBySlug",
     config: {


### PR DESCRIPTION
This feature will fix error in https://github.com/notum-cz/strapi-plugin-record-locking/issues/4

If we use Kubernetes architecture in our project we can use replicas. Kubernetes replicas are clones that facilitate self-healing for pods. As with most processes and services, pods are liable to failure, errors, evictions, and deletion. For instance, pods may fail and be subsequently evicted when there is a sudden drop in system resources and an increase in node pressure.

If we use WebSocket without transport parameters, then WebSocket use default - ["polling", "websocket"]

Polling is mode when browser send a lot of request to our server and get some information about session id.
But, if we have more then 1 replicas all requests send to different pods and returns with different information about session id. Because of this - we have error with code 400

For fix this problem I added new config - transport