### PR TITLE
fix: crashing with latest strapi

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -1,14 +1,9 @@
-const { Server } = require("socket.io")
-const {DEFAULT_TRANSPORTS} = require("./constants/transports");
+const { Server } = require("socket.io");
 
 module.exports = ({ strapi }) => {
   // bootstrap phase
 
-  const config = strapi.config.get('plugin.record-locking')
-
-  const io = new Server(strapi.server.httpServer, {
-    transports: config?.transports || DEFAULT_TRANSPORTS
-  });
+  const io = new Server(strapi.server.httpServer);
 
   io.on("connection", function (socket) {
     socket.on("openEntity", async ({ entitySlug, entityId }) => {


### PR DESCRIPTION
In Strapi urls were changed from camel case (collectionType) to dashed case (collectionTypes) so this PR adjusts to it. Additionally it deletes the transport config as it is not needed anymore because Socket.io chooses the best method automatically.