### PR TITLE
Bug Fix: Entity ID Mismatch in Status Retrievalp unused params

### DIFF
--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -12,7 +12,9 @@ import { getTranslation } from '../../utils/getTranslation';
 const useLockingData = () => {
   const collectionType = useMatch('/content-manager/collection-types/:entityId/:entityDocumentId');
   const singleType = useMatch('/content-manager/single-types/:entityId');
-  const cloneCollectionType = useMatch('/content-manager/collection-types/:entityId/clone/:entityDocumentId');
+  const cloneCollectionType = useMatch(
+    '/content-manager/collection-types/:entityId/clone/:entityDocumentId'
+  );
   const user = useAuth('ENTITY_LOCK', (state) => state.user);
 
   if (!user) return null;
@@ -66,7 +68,12 @@ const useLockStatus = () => {
   useEffect(() => {
     const token = localStorage.getItem('jwtToken') || sessionStorage.getItem('jwtToken');
 
-    if (token && lockingData && lockingData?.requestData.entityDocumentId !== 'create' && settings) {
+    if (
+      token &&
+      lockingData &&
+      lockingData?.requestData.entityDocumentId !== 'create' &&
+      settings
+    ) {
       socket.current = io(undefined, {
         reconnectionDelayMax: 10000,
         rejectUnauthorized: false,

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -23,23 +23,32 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
           ['create', 'delete', 'publish'].some((operation) => perm.action.includes(operation))
         ).length !== 0;
       if (userHasAdequatePermissions) {
-        await strapi.db.query('plugin::record-locking.open-entity').create({
-          data: {
-            user: String(userId),
-            entityId,
-            entityDocumentId,
-            connectionId: socket.id,
-          },
-        });
+        if (entityDocumentId) {
+          await strapi.db.query('plugin::record-locking.open-entity').create({
+            data: {
+              user: String(userId),
+              entityId,
+              entityDocumentId: entityDocumentId,
+              connectionId: socket.id,
+            },
+          });
+        } else {
+          await strapi.db.query('plugin::record-locking.open-entity').create({
+            data: {
+              user: String(userId),
+              entityId,
+              connectionId: socket.id,
+            },
+          });
+        }
       }
     });
 
-    socket.on('closeEntity', async ({ entityId, entityDocumentId, userId }) => {
+    socket.on('closeEntity', async ({ entityId, userId }) => {
       await strapi.db.query('plugin::record-locking.open-entity').deleteMany({
         where: {
           user: String(userId),
-          entityId: entityId,
-          entityDocumentId,
+          entityId,
         },
       });
     });

--- a/server/src/controllers/controller.ts
+++ b/server/src/controllers/controller.ts
@@ -4,43 +4,18 @@ import DEFAULT_TRANSPORTS from '../constants/transports';
 const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
   async getSettings(ctx) {
     const settings = {
-      transports:
-        strapi.plugin('record-locking').config('transports') || DEFAULT_TRANSPORTS,
+      transports: strapi.plugin('record-locking').config('transports') || DEFAULT_TRANSPORTS,
     };
 
     ctx.send(settings);
   },
 
   async getStatusBySlug(ctx) {
-    const { entityDocumentId } = ctx.request.params;
+    const { entityId } = ctx.request.params;
     const { id: userId } = ctx.state.user;
 
     const data = await strapi.db.query('plugin::record-locking.open-entity').findOne({
       where: {
-        entityDocumentId,
-        user: {
-          $not: userId,
-        },
-      },
-    });
-
-    if (data) {
-      const user = await strapi.db.query('admin::user').findOne({ where: { id: data.user } });
-
-      return {
-        editedBy: `${user.firstname} ${user.lastname}`,
-      };
-    }
-
-    return false;
-  },
-
-  async getStatusByIdAndSlug(ctx) {
-    const { entityId, entityDocumentId } = ctx.request.params;
-    const { id: userId } = ctx.state.user;
-    const data = await strapi.db.query('plugin::record-locking.open-entity').findOne({
-      where: {
-        entityDocumentId,
         entityId,
         user: {
           $not: userId,
@@ -59,14 +34,37 @@ const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
     return false;
   },
 
-  async setStatusByIdAndSlug(ctx) {
-    const { entityId, entityDocumentId } = ctx.request.params;
+  async getStatusByIdAndSlug(ctx) {
+    const { entityDocumentId } = ctx.request.params;
     const { id: userId } = ctx.state.user;
+    const data = await strapi.db.query('plugin::record-locking.open-entity').findOne({
+      where: {
+        entityDocumentId,
+        user: {
+          $not: userId,
+        },
+      },
+    });
+
+    if (data) {
+      const user = await strapi.db.query('admin::user').findOne({ where: { id: data.user } });
+
+      return {
+        editedBy: `${user.firstname} ${user.lastname}`,
+      };
+    }
+
+    return false;
+  },
+
+  async setStatusByIdAndSlug(ctx) {
+    const { entityDocumentId } = ctx.request.params;
+    const { id } = ctx.state.user;
+    const currentUserId = String(id);
 
     await strapi.db.query('plugin::record-locking.open-entity').create({
       data: {
-        user: String(userId),
-        entityId: entityId,
+        user: currentUserId,
         entityDocumentId,
       },
     });
@@ -81,7 +79,6 @@ const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
     await strapi.db.query('plugin::record-locking.open-entity').deleteMany({
       where: {
         user: String(userId),
-        entityId: entityId,
         entityDocumentId,
       },
     });

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -9,7 +9,7 @@ export default [
   },
   {
     method: 'GET',
-    path: '/get-status/:entityDocumentId',
+    path: '/get-status/:entityId',
     handler: 'controller.getStatusBySlug',
     config: {
       policies: [],


### PR DESCRIPTION
**Summary**
This PR fixes a bug related to inconsistent parameter usage when retrieving status by slug for single types in a Strapi integration. It aligns backend parameter names with what is sent from the frontend and removes unnecessary logic.

**Changes**
Renamed parameter from entityDocumentId to entityId in `controllers.ts` (`getStatusBySlug()`) and `routes.ts` (`/get-status/:entityId`) to match the frontend input.

Removed unused entityDocumentId when closing an entity — we now delete all items by entityId.

Removed unused entityId in `getStatusByIdAndSlug()` — lookup is handled via entityDocumentId and user.

**Notes**
No breaking changes or migrations.

No related issues — this was identified while integrating the package into a project.

Testing: Install the package into a Strapi project. The modal should now behave correctly and not pop up when two accounts access the same single type or collection type.