### PR TITLE
Fix: Use sessionManager to decode token -> userId for Strapi v5.24.2 onwards

### DIFF
--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -6,13 +6,10 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
 
   const io = new Server(strapi.server.httpServer);
 
-  const getUserIdFromToken = (token: string): string | null => {
-    const userId = strapi.admin.services.token.decodeJwtToken?.(token)?.payload?.id ||
+  const getUserIdFromToken = (token: string): string | undefined  =>
+    strapi.admin.services.token.decodeJwtToken?.(token)?.payload?.id ??
     // @ts-expect-error TS2339: sessionManager does not exist on strapi typings for Strapi < v5.24.2
-    strapi.sessionManager?.('admin').validateAccessToken?.(token)?.payload?.userId ||
-    null;
-    return userId;
-  };
+    strapi.sessionManager?.('admin').validateAccessToken?.(token)?.payload?.userId;
 
   io.on('connection', (socket) => {
     socket.on('openEntity', async ({ entityDocumentId, entityId }) => {
@@ -43,8 +40,7 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
           }
         }
     } catch (error) {
-      console.error('Error creating a record-locking entry.');
-      console.error(error);
+      console.error('Error creating a record-locking entry:', error);
     }
     });
 


### PR DESCRIPTION
## Issue:
For Strapi v5.24.2 onwards, the plugin crashing with an error `TypeError: strapi.admin.services.token.decodeJwtToken is not a function` on the server-side. 

## Root Cause:
Strapi v5.24.2 has introduced Advanced Session Configuration and as part of this feature, the `strapi.admin.services.token.decodeJwtToken` is no longer available.

## Environment:
Strapi version: v5.24.2
Plugin version: v2.0.0
Node version: v20.9.0

## Fix:
- Added JWT token decoding via `sessionManager` (specifically `strapi.sessionManager.('admin').validateAccessToken(socket.handshake.auth.token)`) when `strapi.admin.services.token.decodeJwtToken` is undefined (expected `v5.24.2` onwards).
- For earlier versions, the `strapi.admin.services.token.decodeJwtToken` will work as-is.
- Added userId null check and error-handling to avoid plugin crash for the code that acquires lock.
- In case of an unhandled issue when trying to add an entry to `open-entity` in the future (to aquire lock), a console error will be displayed.

## Steps to Verify:
- Perform the below steps with Strapi versions <= v5.23.6 *and* >= v5.24.2
- Ensure `record-locking` plugin is installed and enabled.
- As admin, open any record within the Content Manager to Edit.
- In another tab, check if the Open Entity collection has matching record for the record in editing.