### PR TITLE
Chore: updating the plugin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
-    "@strapi/sdk-plugin": "^5.2.6",
+    "@strapi/sdk-plugin": "^5.3.2",
     "@strapi/strapi": "^5.4.0",
     "@strapi/typescript-utils": "^5.0.0",
     "@types/react": "^18.3.12",
@@ -68,7 +68,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@strapi/sdk-plugin": "^5.2.6",
+    "@strapi/sdk-plugin": "^5.3.2",
     "@strapi/strapi": "^5.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,10 +2239,10 @@
     react-redux "8.1.3"
     yup "0.32.9"
 
-"@strapi/sdk-plugin@^5.2.6":
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/@strapi/sdk-plugin/-/sdk-plugin-5.2.6.tgz#6d6679b1cc2f070dbbc33da4f31baacb7863c8da"
-  integrity sha512-nMbQEiP1QvjUWEoDvG6/4aw0QORC6gL9hE7zxgQh6B6rKUvdw06nhzfMTYocfHyP/GKMourcsdzKGbz1NuIwvw==
+"@strapi/sdk-plugin@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@strapi/sdk-plugin/-/sdk-plugin-5.3.2.tgz#4a1cdeeb0cf9ac98246ba96e0c11073a891c36fa"
+  integrity sha512-BQTVhnLIIOg9nfP1VbH3Uw4AXZKyy8ULU1u6lhiMFlNZCn8P4rG22pnWiBWEVU3dR9aWdaFSZLrYzVDFeoNxUQ==
   dependencies:
     "@strapi/pack-up" "^5.0.1"
     "@types/prompts" "2.4.9"


### PR DESCRIPTION
- `react-intl` from ^6.7.0 to ^7.1.14
- `socket.io`, `socket.io-client` from ^4.8.0 to ^4.8.1
- `@strapi/icons`, `@strapi/design-system` from ^2.0.0-rc.11 to ^2.0.0-rc.30
- `@strapi/sdk-plugin` from ^5.2.6 to ^5.3.2

Checks performed after updating the dependencies:
- Locking and unlocking of records of collections and single-types (for `socket.io`, `socket.io-client`)
- Translations for locking modal messages (for `react-intl`)
- Modal display (for `@strapi/icons`, `@strapi/design-system`)