### PR TITLE
Fix locking /get-status/ for single types

### DIFF
--- a/server/src/controllers/controller.ts
+++ b/server/src/controllers/controller.ts
@@ -12,12 +12,12 @@ const controller = ({ strapi }: { strapi: Core.Strapi }) => ({
   },
 
   async getStatusBySlug(ctx) {
-    const { entityDocumentId } = ctx.request.params;
+    const { entityId } = ctx.request.params;
     const { id: userId } = ctx.state.user;
 
     const data = await strapi.db.query('plugin::record-locking.open-entity').findOne({
       where: {
-        entityDocumentId,
+        entityId,
         user: {
           $not: userId,
         },

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -9,7 +9,7 @@ export default [
   },
   {
     method: 'GET',
-    path: '/get-status/:entityDocumentId',
+    path: '/get-status/:entityId',
     handler: 'controller.getStatusBySlug',
     config: {
       policies: [],


### PR DESCRIPTION
Currently, the operation `/record-locking/get-status/<slug>` always returns a `false` (meaning the requested record isn't locked) when checking for an existing lock for single-types. This happens because:

- For single-types, the request checking for an existing lock is like `/record-locking/get-status/<slug>` (eg : `http://localhost:1337/record-locking/get-status/api::navmenu.navmenu`)
- On the server-side, when querying the `plugin::record-locking.open-entity` collection looking for a lock, the obtained `slug` gets treated as `entityDocumentId` instead of `entityId` leading to no matching record found.

This PR ensures `'/get-status/:entityDocumentId'` is changed to `'/get-status/:entityId'`. This should ensure locking for single-types works as expected.

