### PR TITLE
Avoid deleteMany during destroy cleanup when db metadata not mounted

### DIFF
--- a/server/src/destroy.ts
+++ b/server/src/destroy.ts
@@ -5,8 +5,9 @@ const destroy = ({ strapi }: { strapi: Core.Strapi & {io?: Server} }) => {
   if (strapi?.io?.close) {
     strapi.io.close();
   }
-  
-  strapi.db.query('plugin::record-locking.open-entity').deleteMany();
+  if (strapi.db.metadata.has('plugin::record-locking.open-entity')) {
+    strapi.db.query('plugin::record-locking.open-entity').deleteMany();
+  }
 };
 
 export default destroy;


### PR DESCRIPTION
Fixes Issue [150](https://github.com/notum-cz/strapi-plugin-record-locking/issues/150) : The error `Error: Model plugin::record-locking.open-entity not found` encountered with the commands `yarn run strapi ts:generate-types` and `yarn strapi hooks:list`

Tests verified:
- Ensure that the commands `yarn run strapi ts:generate-types` and `yarn strapi hooks:list` do not error.
- Ensure that, as earlier, `record-locking` collection cleanup happens as earlier when Strapi is closed.