### PR TITLE
Feature: Replace EntityLock modal with a dialog

### DIFF
--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -6,7 +6,7 @@ import { io, Socket } from 'socket.io-client';
 import { useMatch, useNavigate } from 'react-router-dom';
 
 import { Dialog } from '@strapi/design-system';
-import { useAuth, useFetchClient } from '@strapi/strapi/admin';
+import { useAuth, useFetchClient, useNotification } from '@strapi/strapi/admin';
 import { getTranslation } from '../../utils/getTranslation';
 import { getStoredToken } from '../../utils/getStoredToken';
 
@@ -50,6 +50,8 @@ const useLockingData = () => {
 };
 
 const useLockStatus = () => {
+  const { toggleNotification } = useNotification();
+  const { formatMessage } = useIntl();
   const { get } = useFetchClient();
   const lockingData = useLockingData();
 
@@ -129,6 +131,14 @@ const useLockStatus = () => {
           setIsTakenOver(false);
         } else {
           console.warn(response.error);
+
+          toggleNotification({ 
+            type: 'danger', 
+            title: formatMessage({
+              id: getTranslation('ModalWindow.TakeoverCurrentlyEditing.Error'),
+              defaultMessage: 'Failed to takeover the entity lock',
+            }),
+          })
         }
     });
   };

--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -186,7 +186,12 @@ export default function EntityLock() {
           </Dialog.Body>
           <Dialog.Footer gap={2}>
             <Dialog.Action onClick={() => navigate(-1)}>
-              <Button fullWidth variant="tertiary">
+              <Button
+                fullWidth
+                variant={
+                  (lockStatus.settings?.showTakeoverButton ?? false) ? 'tertiary' : undefined
+                }
+              >
                 {formatMessage({
                   id: getTranslation('ModalWindow.CurrentlyEditing.Button'),
                   defaultMessage: 'Go Back',

--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -5,7 +5,7 @@ import { io, Socket } from 'socket.io-client';
 
 import { useMatch, useNavigate } from 'react-router-dom';
 
-import { Modal } from '@strapi/design-system';
+import { Dialog } from '@strapi/design-system';
 import { useAuth, useFetchClient } from '@strapi/strapi/admin';
 import { getTranslation } from '../../utils/getTranslation';
 import { getStoredToken } from '../../utils/getStoredToken';
@@ -152,60 +152,60 @@ export default function EntityLock() {
 
   return (
     lockStatus.isLocked && (
-      <Modal.Root defaultOpen={true}>
-        <Modal.Content>
-          <Modal.Header>
-            <Typography fontWeight="bold" textColor="neutral800" tag="h2" id="title">
+      <Dialog.Root defaultOpen={true}>
+        <Dialog.Content onEscapeKeyDown={(e) => e.preventDefault()}>
+          <Dialog.Header>
               {formatMessage({
                 id: getTranslation('ModalWindow.CurrentlyEditing'),
-                defaultMessage: 'This entry is currently edited',
+                defaultMessage: 'Someone is editing this record',
               })}
-            </Typography>
-          </Modal.Header>
-          <Modal.Body>
-            <Typography>
+          </Dialog.Header>
+          <Dialog.Body>
+            <Typography variant="omega" textAlign="center">
               {formatMessage(
                 {
-                  id: lockStatus.isTakenOver ? getTranslation('ModalWindow.CurrentlyTakenOverBody') : getTranslation('ModalWindow.CurrentlyEditingBody'),
-                  defaultMessage: lockStatus.isTakenOver ? 'This entry is taken over for editing by {username}' : 'This entry is currently edited by {username}',
+                  id: lockStatus.isTakenOver
+                    ? getTranslation('ModalWindow.CurrentlyTakenOverBody')
+                    : getTranslation('ModalWindow.CurrentlyEditingBody'),
+                  defaultMessage: lockStatus.isTakenOver
+                    ? 'This entry is taken over for editing by {username}'
+                    : 'This entry is currently edited by {username}',
                 },
                 {
-                  username: <Typography fontWeight="bold">{lockStatus.username}</Typography>,
+                  username: (
+                    <>
+                      <br />
+                      <Typography variant="epsilon" fontWeight="bold">
+                        {lockStatus.username}
+                      </Typography>
+                    </>
+                  ),
                 }
               )}
             </Typography>
-          </Modal.Body>
-          <Modal.Footer>
-            <Modal.Close>
-              <Button variant="tertiary">OK</Button>
-            </Modal.Close>
-            <Flex gap={2} direction="row">
-              {
-                (lockStatus.settings?.showTakeoverButton ?? false) && (
-                  <Button
-                  onClick={lockStatus.takeoverEntityLock}
-                >
+          </Dialog.Body>
+          <Dialog.Footer gap={2}>
+            <Dialog.Action onClick={() => navigate(-1)}>
+              <Button fullWidth variant="tertiary">
+                {formatMessage({
+                  id: getTranslation('ModalWindow.CurrentlyEditing.Button'),
+                  defaultMessage: 'Go Back',
+                })}
+              </Button>
+            </Dialog.Action>
+            {(lockStatus.settings?.showTakeoverButton ?? false) && (
+              <Dialog.Action onClick={lockStatus.takeoverEntityLock}>
+                <Button fullWidth>
                   {formatMessage({
                     id: getTranslation('ModalWindow.TakeoverCurrentlyEditing.Button'),
                     defaultMessage: 'Takeover',
                   })}
                 </Button>
-                )
-              }
-            <Button
-              onClick={() => {
-                navigate(-1);
-              }}
-            >
-              {formatMessage({
-                id: getTranslation('ModalWindow.CurrentlyEditing.Button'),
-                defaultMessage: 'Go Back',
-              })}
-            </Button>
-            </Flex>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal.Root>
+              </Dialog.Action>
+            )}
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog.Root>
     )
   );
 }

--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography, Flex } from '@strapi/design-system';
+import { Button, Typography } from '@strapi/design-system';
 import { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { io, Socket } from 'socket.io-client';

--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -169,7 +169,7 @@ export default function EntityLock() {
                     : getTranslation('ModalWindow.CurrentlyEditingBody'),
                   defaultMessage: lockStatus.isTakenOver
                     ? 'This entry is taken over for editing by {username}'
-                    : 'This entry is currently edited by {username}',
+                    : 'This entry is currently being edited by {username}',
                 },
                 {
                   username: (

--- a/admin/src/components/EntityLock/index.tsx
+++ b/admin/src/components/EntityLock/index.tsx
@@ -171,28 +171,30 @@ export default function EntityLock() {
               })}
           </Dialog.Header>
           <Dialog.Body>
-            <Typography variant="omega" textAlign="center">
-              {formatMessage(
-                {
-                  id: lockStatus.isTakenOver
-                    ? getTranslation('ModalWindow.CurrentlyTakenOverBody')
-                    : getTranslation('ModalWindow.CurrentlyEditingBody'),
-                  defaultMessage: lockStatus.isTakenOver
-                    ? 'This entry is taken over for editing by {username}'
-                    : 'This entry is currently being edited by {username}',
-                },
-                {
-                  username: (
-                    <>
-                      <br />
-                      <Typography variant="epsilon" fontWeight="bold">
-                        {lockStatus.username}
-                      </Typography>
-                    </>
-                  ),
-                }
-              )}
-            </Typography>
+            <Dialog.Description>
+              <Typography variant="omega" textAlign="center">
+                {formatMessage(
+                  {
+                    id: lockStatus.isTakenOver
+                      ? getTranslation('ModalWindow.CurrentlyTakenOverBody')
+                      : getTranslation('ModalWindow.CurrentlyEditingBody'),
+                    defaultMessage: lockStatus.isTakenOver
+                      ? 'This entry is taken over for editing by {username}'
+                      : 'This entry is currently being edited by {username}',
+                  },
+                  {
+                    username: (
+                      <>
+                        <br />
+                        <Typography variant="epsilon" fontWeight="bold">
+                          {lockStatus.username}
+                        </Typography>
+                      </>
+                    ),
+                  }
+                )}
+              </Typography>
+            </Dialog.Description>
           </Dialog.Body>
           <Dialog.Footer gap={2}>
             <Dialog.Action onClick={() => navigate(-1)}>

--- a/admin/src/translations/cs.json
+++ b/admin/src/translations/cs.json
@@ -3,5 +3,6 @@
   "ModalWindow.CurrentlyEditingBody": "S tímto záznamem aktuálně pracuje {username}",
   "ModalWindow.CurrentlyEditing.Button": "Zpět na seznam",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Převzít",
-  "ModalWindow.CurrentlyTakenOverBody": "Tento záznam přebírá k úpravám uživatel {username}."
+  "ModalWindow.CurrentlyTakenOverBody": "Tento záznam přebírá k úpravám uživatel {username}.",
+  "ModalWindow.TakeoverCurrentlyEditing.Error": "Nepodařilo se převzít zámek entity"
 }

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -3,5 +3,6 @@
   "ModalWindow.CurrentlyEditingBody": "Dieser Eintrag wird gerade durch {username} bearbeitet.",
   "ModalWindow.CurrentlyEditing.Button": "Geh zurück",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Übernahme",
-  "ModalWindow.CurrentlyTakenOverBody": "Dieser Eintrag wird von {username} bearbeitet."
+  "ModalWindow.CurrentlyTakenOverBody": "Dieser Eintrag wird von {username} bearbeitet.",
+  "ModalWindow.TakeoverCurrentlyEditing.Error": "Die Übernahme der Entitätssperre ist fehlgeschlagen"
 }

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -1,5 +1,5 @@
 {
-  "ModalWindow.CurrentlyEditing": "Dieser Eintrag wird gerade bearbeitet",
+  "ModalWindow.CurrentlyEditing": "Jemand bearbeitet gerade diesen Datensatz",
   "ModalWindow.CurrentlyEditingBody": "Dieser Eintrag wird gerade durch {username} bearbeitet.",
   "ModalWindow.CurrentlyEditing.Button": "Zurück",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Übernahme",

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -1,7 +1,7 @@
 {
   "ModalWindow.CurrentlyEditing": "Jemand bearbeitet gerade diesen Datensatz",
   "ModalWindow.CurrentlyEditingBody": "Dieser Eintrag wird gerade durch {username} bearbeitet.",
-  "ModalWindow.CurrentlyEditing.Button": "Zurück",
+  "ModalWindow.CurrentlyEditing.Button": "Geh zurück",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Übernahme",
   "ModalWindow.CurrentlyTakenOverBody": "Dieser Eintrag wird von {username} bearbeitet."
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -3,5 +3,6 @@
   "ModalWindow.CurrentlyEditingBody": "This entry is currently being edited by {username}",
   "ModalWindow.CurrentlyEditing.Button": "Go Back",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Takeover",
-  "ModalWindow.CurrentlyTakenOverBody": "This entry is taken over for editing by {username}"
+  "ModalWindow.CurrentlyTakenOverBody": "This entry is taken over for editing by {username}",
+  "ModalWindow.TakeoverCurrentlyEditing.Error": "Failed to takeover the entity lock"
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "ModalWindow.CurrentlyEditing": "This entry is currently being edited",
+  "ModalWindow.CurrentlyEditing": "Someone is editing this record",
   "ModalWindow.CurrentlyEditingBody": "This entry is currently being edited by {username}",
   "ModalWindow.CurrentlyEditing.Button": "Back",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Takeover",

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,7 +1,7 @@
 {
   "ModalWindow.CurrentlyEditing": "Someone is editing this record",
   "ModalWindow.CurrentlyEditingBody": "This entry is currently being edited by {username}",
-  "ModalWindow.CurrentlyEditing.Button": "Back",
+  "ModalWindow.CurrentlyEditing.Button": "Go Back",
   "ModalWindow.TakeoverCurrentlyEditing.Button": "Takeover",
   "ModalWindow.CurrentlyTakenOverBody": "This entry is taken over for editing by {username}"
 }


### PR DESCRIPTION
## Description

This PR updates the `EntityLock` popup component from a Modal to a Dialog. 

Currently, the lock notification relies on a standard modal component. Switching to a dialog improves both the visual presentation and the functional workflow in a few key ways:

- **Cleaner, consistent UI:** The dialog format fits much better visually alongside Strapi's design patterns for critical prompts and system alerts.
- **Enforced user action:** Modals can often be dismissed by clicking on the background overlay or pressing the Escape key. For document locking, dismissing the prompt leaves the UI in an ambiguous state. Using a dialog prevents outside dismissal, requiring the user to explicitly select an action—either navigating back to safety or taking over editing control of the document.

---

## TL;DR

Replaced the `EntityLock` modal with a non-dismissible dialog to prevent users from accidentally closing the popup and force an explicit choice between going back or taking over the edit lock.

---

## Screenshots

#### `showTakeoverButton: true`

<img width="1440" height="654" alt="Screenshot 2026-07-21 at 20 53 50" src="https://github.com/user-attachments/assets/518c685e-6ef5-4d16-a7ad-ae744f3ce2ff" />

<img width="1440" height="654" alt="Screenshot 2026-07-21 at 20 54 35" src="https://github.com/user-attachments/assets/fca8f933-279c-4241-b02b-a9e56df160b7" />

#### `showTakeoverButton: false`

<img width="1440" height="657" alt="Screenshot 2026-07-21 at 20 56 36" src="https://github.com/user-attachments/assets/390fbba1-1d0d-4140-9d1a-8f3c30d3ef60" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed the record-lock warning dialog layout and messaging, including a “Go Back” action.
  * Prevented accidental dismissal of the dialog via the Escape key.
  * Conditionally shows the “Takeover” option based on enabled settings.
  * Updated German and English translation text for the “Currently editing” dialog and its button label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->